### PR TITLE
Fix docker-compose instructions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -11,7 +11,7 @@ Get the docker-compose file and bring it up:
 (You may edit **isardvdi.conf** parameters file prior to bringing up IsardVDI and adapt it to your installation. By default IsardVDI will start with self-signed certificate if no *letsencrypt* parameters defined in isardvdi.conf file.)
 
 ```bash
-wget https://raw.githubusercontent.com/isard-vdi/isard/master/docker-compose.yml.example
+wget https://isardvdi.com/docker-compose.yml
 docker-compose pull
 docker-compose up -d
 ```

--- a/docs/install/install.md
+++ b/docs/install/install.md
@@ -51,7 +51,7 @@ egrep ‘(vmx|svm)’ /proc/cpuinfo
 To bring up IsardVDI you only need to download the docker-compose.yml file (or clone the full repo if you want to build the images yourself) and bring it up:
 
 ```bash
-wget https://raw.githubusercontent.com/isard-vdi/isard/master/docker-compose.yml
+wget https://isardvdi.com/docker-compose.yml
 docker-compose pull
 docker-compose up -d
 ```


### PR DESCRIPTION
Assuming that develop branch will be master branch, the instructions
without this change download the docker-compose.yml.example file but is
not renamed to docker-compose.yml, the default file used by
docker-compose without using the -f flag.

This change fixes it using the instructions from the isardvdi.com website.